### PR TITLE
Board initialize

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -9,5 +9,11 @@ class Board
   end
 
   def generate_cells
+    cell_hash = {}
+    coordinates = ["A1", "A2", "A3", "A4", "B1", "B2", "B3", "B4", "C1", "C2", "C3", "C4", "D1", "D2", "D3", "D4"]
+    coordinates.each do |coordinate|
+      cell_hash[coordinate] = Cell.new(coordinate)
+    end
+    cell_hash
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,0 +1,13 @@
+require "./lib/ship"
+require "./lib/cell"
+
+class Board
+  attr_reader :cells
+
+  def initialize
+    @cells = generate_cells
+  end
+
+  def generate_cells
+  end
+end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -9,4 +9,12 @@ class BoardTest < Minitest::Test
 
     assert_instance_of Board, board
   end
+
+  def test_it_holds_cells
+    board = Board.new
+
+    assert_equal 16, board.cells.keys.count
+    assert_equal 16, board.cells.values.count
+    assert_instance_of Cell, board.cells["D4"]
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -1,0 +1,12 @@
+require "minitest/autorun"
+require "minitest/pride"
+require "./lib/board"
+
+class BoardTest < Minitest::Test
+
+  def test_it_is_a_board
+    board = Board.new
+
+    assert_instance_of Board, board
+  end
+end


### PR DESCRIPTION
Contains the initialization and generate_cells methods for Board class
- initialize without argument
- generates cells as part of initialize
- tested and working
closes #19 