### PR TITLE
Add Board render_prep method, which adds row/column info to render

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -54,9 +54,18 @@ class Board
     end
   end
 
+  def render_prep(reveal = false)
+    base = render_base(reveal)
+    base.insert(12, "D")
+    base.insert(8, "C")
+    base.insert(4, "B")
+    base.unshift([" ", "1", "2", "3", "4", "A"]).flatten!
+    base
+  end
+
   def render(reveal = false)
     text_to_render = []
-    render_base(reveal).each_slice(4) do |line|
+    render_prep(reveal).each_slice(5) do |line|
       text_to_render << line.join(" ")
     end
     text_to_render.join("\n")

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -95,14 +95,14 @@ class BoardTest < Minitest::Test
   def test_rendering_bare_board
     board = Board.new
 
-    assert_equal ". . . .\n. . . .\n. . . .\n. . . .", board.render
+    assert_equal "  1 2 3 4\nA . . . .\nB . . . .\nC . . . .\nD . . . .", board.render
   end
 
   def test_rendering_board_with_misses
     board = Board.new
     board.cells["B4"].fire_upon
 
-    assert_equal ". . . .\n. . . M\n. . . .\n. . . .", board.render
+    assert_equal "  1 2 3 4\nA . . . .\nB . . . M\nC . . . .\nD . . . .", board.render
   end
 
   def test_render_with_ships
@@ -119,7 +119,7 @@ class BoardTest < Minitest::Test
     board.cells["C2"].fire_upon
     board.cells["D3"].fire_upon
 
-    assert_equal "X X X .\n. . . .\n. M . .\n. . H .", board.render
-    assert_equal "X X X .\n. . . .\n. M S .\n. . H .", board.render(true)
+    assert_equal "  1 2 3 4\nA X X X .\nB . . . .\nC . M . .\nD . . H .", board.render
+    assert_equal "  1 2 3 4\nA X X X .\nB . . . .\nC . M S .\nD . . H .", board.render(true)
   end
 end


### PR DESCRIPTION
This update adds

- Board render_prep method (accepts optional reveal arg)

Fully tested. 

This fixes the Board render method to render the column and row tittles as well as the cell contents. 
closes #28 